### PR TITLE
Modify PokemonStat composable

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+Livescore

--- a/app/src/main/java/com/example/livescore/data/local/converters/Converters.kt
+++ b/app/src/main/java/com/example/livescore/data/local/converters/Converters.kt
@@ -12,7 +12,9 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 
 @ProvidedTypeConverter
-class Converters{
+class Converters(
+    private val gson: Gson
+){
 
     // Away team converter
     @TypeConverter

--- a/app/src/main/java/com/example/livescore/data/local/converters/Converters.kt
+++ b/app/src/main/java/com/example/livescore/data/local/converters/Converters.kt
@@ -12,9 +12,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 
 @ProvidedTypeConverter
-class Converters(
-    private val gson: Gson
-) {
+class Converters{
 
     // Away team converter
     @TypeConverter

--- a/app/src/main/java/com/example/livescore/presentation/screens/matchdetails/components/TabContentDetails.kt
+++ b/app/src/main/java/com/example/livescore/presentation/screens/matchdetails/components/TabContentDetails.kt
@@ -2,10 +2,9 @@ package com.example.livescore.presentation.screens.matchdetails.components
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement.SpaceBetween
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -15,11 +14,12 @@ import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.Alignment.Companion.Center
-import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Alignment.Companion.End
 import androidx.compose.ui.Modifier
@@ -40,22 +40,22 @@ import com.example.livescore.ui.theme.SpAtkColor
 @Composable
 fun TabScreenOne(tabName: String, match: List<MatchEvent>, one: Int, two: Int) {
     Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
     ) {
         Card(
-            modifier = Modifier
-                .padding(6.dp)
-                .fillMaxSize(),
-            shape = RoundedCornerShape(6.dp),
-            elevation = 3.dp,
+                modifier = Modifier
+                        .padding(6.dp)
+                        .fillMaxSize(),
+                shape = RoundedCornerShape(6.dp),
+                elevation = 3.dp,
         ) {
 
             LazyColumn(
-                modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .fillMaxSize()
+                    modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .fillMaxSize()
 
             ) {
                 items(items = match) { item ->
@@ -67,38 +67,38 @@ fun TabScreenOne(tabName: String, match: List<MatchEvent>, one: Int, two: Int) {
                                 if (item.type == "goal") {
                                     Row(modifier = Modifier.padding(start = 16.dp, top = 8.dp)) {
                                         Text(
-                                            text = item.minute.toString(),
-                                            fontWeight = FontWeight.Bold,
-                                            modifier = Modifier.align(Alignment.CenterVertically),
-                                            fontSize = 15.sp
+                                                text = item.minute.toString(),
+                                                fontWeight = FontWeight.Bold,
+                                                modifier = Modifier.align(Alignment.CenterVertically),
+                                                fontSize = 15.sp
                                         )
 
                                         Spacer(modifier = Modifier.width(10.dp))
 
                                         Image(
-                                            painter = painterResource(id = R.drawable.reggae),
-                                            modifier = Modifier
-                                                .height(38.dp)
-                                                .width(38.dp)
-                                                .padding(10.dp)
-                                                .align(Alignment.CenterVertically),
-                                            contentDescription = "",
+                                                painter = painterResource(id = R.drawable.reggae),
+                                                modifier = Modifier
+                                                        .height(38.dp)
+                                                        .width(38.dp)
+                                                        .padding(10.dp)
+                                                        .align(Alignment.CenterVertically),
+                                                contentDescription = "",
 
-                                        )
+                                                )
 
                                         Spacer(modifier = Modifier.width(4.dp))
 
                                         Column(modifier = Modifier.align(Alignment.CenterVertically)) {
                                             Text(
-                                                text = item.player_name + "(${item.result})",
-                                                fontWeight = FontWeight.Bold,
-                                                fontSize = 14.sp
+                                                    text = item.player_name + "(${item.result})",
+                                                    fontWeight = FontWeight.Bold,
+                                                    fontSize = 14.sp
                                             )
                                             if (item.related_player_name != null) {
                                                 Text(
-                                                    text = "Assist by " + item.related_player_name,
-                                                    color = Color.Gray,
-                                                    fontSize = 12.sp
+                                                        text = "Assist by " + item.related_player_name,
+                                                        color = Color.Gray,
+                                                        fontSize = 12.sp
                                                 )
                                             }
                                         }
@@ -107,33 +107,33 @@ fun TabScreenOne(tabName: String, match: List<MatchEvent>, one: Int, two: Int) {
                                 if (item.type == "substitution") {
                                     Row(modifier = Modifier.padding(start = 16.dp, top = 8.dp)) {
                                         Text(
-                                            text = item.minute.toString(),
-                                            fontWeight = FontWeight.Bold,
-                                            modifier = Modifier.align(Alignment.CenterVertically),
-                                            fontSize = 15.sp
+                                                text = item.minute.toString(),
+                                                fontWeight = FontWeight.Bold,
+                                                modifier = Modifier.align(Alignment.CenterVertically),
+                                                fontSize = 15.sp
                                         )
 
                                         Spacer(modifier = Modifier.width(18.dp))
 
                                         Column {
                                             Card(
-                                                shape = RoundedCornerShape(100.dp),
-                                                modifier = Modifier.padding(top = 4.dp)
+                                                    shape = RoundedCornerShape(100.dp),
+                                                    modifier = Modifier.padding(top = 4.dp)
                                             ) {
                                                 Column {
                                                     Row(
-                                                        modifier = Modifier
-                                                            .size(14.dp)
-                                                            .background(Color.Green)
+                                                            modifier = Modifier
+                                                                    .size(14.dp)
+                                                                    .background(Color.Green)
                                                     ) {
                                                         Image(
-                                                            imageVector = Icons.Default.ArrowForward,
-                                                            modifier = Modifier
-                                                                .fillMaxSize()
-                                                                .padding(2.dp)
-                                                                .align(Alignment.CenterVertically),
-                                                            contentDescription = "",
-                                                            colorFilter = ColorFilter.tint(Color.White)
+                                                                imageVector = Icons.Default.ArrowForward,
+                                                                modifier = Modifier
+                                                                        .fillMaxSize()
+                                                                        .padding(2.dp)
+                                                                        .align(Alignment.CenterVertically),
+                                                                contentDescription = "",
+                                                                colorFilter = ColorFilter.tint(Color.White)
                                                         )
                                                     }
                                                 }
@@ -142,23 +142,23 @@ fun TabScreenOne(tabName: String, match: List<MatchEvent>, one: Int, two: Int) {
                                             Spacer(modifier = Modifier.height(1.dp))
 
                                             Card(
-                                                shape = RoundedCornerShape(100.dp),
-                                                modifier = Modifier
+                                                    shape = RoundedCornerShape(100.dp),
+                                                    modifier = Modifier
                                             ) {
                                                 Column {
                                                     Row(
-                                                        modifier = Modifier
-                                                            .size(14.dp)
-                                                            .background(Color.Red)
+                                                            modifier = Modifier
+                                                                    .size(14.dp)
+                                                                    .background(Color.Red)
                                                     ) {
                                                         Image(
-                                                            imageVector = Icons.Default.ArrowBack,
-                                                            modifier = Modifier
-                                                                .fillMaxSize()
-                                                                .padding(2.dp)
-                                                                .align(Alignment.CenterVertically),
-                                                            contentDescription = "",
-                                                            colorFilter = ColorFilter.tint(Color.White)
+                                                                imageVector = Icons.Default.ArrowBack,
+                                                                modifier = Modifier
+                                                                        .fillMaxSize()
+                                                                        .padding(2.dp)
+                                                                        .align(Alignment.CenterVertically),
+                                                                contentDescription = "",
+                                                                colorFilter = ColorFilter.tint(Color.White)
                                                         )
                                                     }
                                                 }
@@ -168,16 +168,16 @@ fun TabScreenOne(tabName: String, match: List<MatchEvent>, one: Int, two: Int) {
 
                                         Column {
                                             Text(
-                                                text = item.related_player_name,
-                                                fontSize = 14.sp,
-                                                color = Color.Green
+                                                    text = item.related_player_name,
+                                                    fontSize = 14.sp,
+                                                    color = Color.Green
                                             )
                                             Spacer(modifier = Modifier.height(1.dp))
 
                                             Text(
-                                                text = item.player_name,
-                                                fontSize = 14.sp,
-                                                color = Color.Red
+                                                    text = item.player_name,
+                                                    fontSize = 14.sp,
+                                                    color = Color.Red
                                             )
                                         }
                                     }
@@ -185,117 +185,117 @@ fun TabScreenOne(tabName: String, match: List<MatchEvent>, one: Int, two: Int) {
 
                                 if (item.type == "yellowcard") {
                                     Row(
-                                        modifier = Modifier.padding(
-                                            start = 16.dp,
-                                            top = 8.dp,
-                                            bottom = 8.dp
-                                        )
+                                            modifier = Modifier.padding(
+                                                    start = 16.dp,
+                                                    top = 8.dp,
+                                                    bottom = 8.dp
+                                            )
                                     ) {
                                         Text(
-                                            text = item.minute.toString(),
-                                            fontWeight = FontWeight.Bold,
-                                            modifier = Modifier.align(Alignment.CenterVertically),
-                                            fontSize = 15.sp
+                                                text = item.minute.toString(),
+                                                fontWeight = FontWeight.Bold,
+                                                modifier = Modifier.align(Alignment.CenterVertically),
+                                                fontSize = 15.sp
                                         )
 
                                         Spacer(modifier = Modifier.width(18.dp))
 
                                         Card(
-                                            modifier = Modifier
-                                                .align(Alignment.CenterVertically)
-                                                .height(16.dp)
-                                                .width(12.dp)
-                                                .background(
-                                                    Color.Yellow
-                                                )
+                                                modifier = Modifier
+                                                        .align(Alignment.CenterVertically)
+                                                        .height(16.dp)
+                                                        .width(12.dp)
+                                                        .background(
+                                                                Color.Yellow
+                                                        )
                                         ) {
                                             Box(
-                                                modifier = Modifier
-                                                    .fillMaxSize()
-                                                    .background(Color.Yellow)
+                                                    modifier = Modifier
+                                                            .fillMaxSize()
+                                                            .background(Color.Yellow)
                                             )
                                         }
 
                                         Spacer(modifier = Modifier.width(20.dp))
 
                                         Text(
-                                            text = item.player_name,
-                                            fontSize = 14.sp,
-                                            modifier = Modifier.align(CenterVertically)
+                                                text = item.player_name,
+                                                fontSize = 14.sp,
+                                                modifier = Modifier.align(CenterVertically)
                                         )
                                     }
                                 }
 
                                 if (item.type == "injury") {
                                     Row(
-                                        modifier = Modifier.padding(
-                                            start = 16.dp,
-                                            top = 8.dp,
-                                            bottom = 8.dp
-                                        )
+                                            modifier = Modifier.padding(
+                                                    start = 16.dp,
+                                                    top = 8.dp,
+                                                    bottom = 8.dp
+                                            )
                                     ) {
                                         Text(
-                                            text = item.minute.toString(),
-                                            fontWeight = FontWeight.Bold,
-                                            modifier = Modifier.align(Alignment.CenterVertically),
-                                            fontSize = 15.sp
+                                                text = item.minute.toString(),
+                                                fontWeight = FontWeight.Bold,
+                                                modifier = Modifier.align(Alignment.CenterVertically),
+                                                fontSize = 15.sp
                                         )
 
                                         Spacer(modifier = Modifier.width(18.dp))
 
                                         Image(
-                                            imageVector = Icons.Default.Warning,
-                                            modifier = Modifier
-                                                .size(22.dp)
-                                                .padding(2.dp)
-                                                .align(Alignment.CenterVertically),
-                                            contentDescription = "",
-                                            colorFilter = ColorFilter.tint(Color.Red)
+                                                imageVector = Icons.Default.Warning,
+                                                modifier = Modifier
+                                                        .size(22.dp)
+                                                        .padding(2.dp)
+                                                        .align(Alignment.CenterVertically),
+                                                contentDescription = "",
+                                                colorFilter = ColorFilter.tint(Color.Red)
                                         )
 
                                         Spacer(modifier = Modifier.width(20.dp))
 
                                         Text(
-                                            text = item.player_name,
-                                            fontSize = 14.sp,
-                                            modifier = Modifier.align(CenterVertically)
+                                                text = item.player_name,
+                                                fontSize = 14.sp,
+                                                modifier = Modifier.align(CenterVertically)
                                         )
                                     }
                                 }
 
                                 if (item.type == "back from injury") {
                                     Row(
-                                        modifier = Modifier.padding(
-                                            start = 16.dp,
-                                            top = 8.dp,
-                                            bottom = 8.dp
-                                        )
+                                            modifier = Modifier.padding(
+                                                    start = 16.dp,
+                                                    top = 8.dp,
+                                                    bottom = 8.dp
+                                            )
                                     ) {
                                         Text(
-                                            text = item.minute.toString(),
-                                            fontWeight = FontWeight.Bold,
-                                            modifier = Modifier.align(Alignment.CenterVertically),
-                                            fontSize = 15.sp
+                                                text = item.minute.toString(),
+                                                fontWeight = FontWeight.Bold,
+                                                modifier = Modifier.align(Alignment.CenterVertically),
+                                                fontSize = 15.sp
                                         )
 
                                         Spacer(modifier = Modifier.width(18.dp))
 
                                         Image(
-                                            imageVector = Icons.Default.Add,
-                                            modifier = Modifier
-                                                .size(22.dp)
-                                                .padding(2.dp)
-                                                .align(Alignment.CenterVertically),
-                                            contentDescription = "",
-                                            colorFilter = ColorFilter.tint(Color.Green)
+                                                imageVector = Icons.Default.Add,
+                                                modifier = Modifier
+                                                        .size(22.dp)
+                                                        .padding(2.dp)
+                                                        .align(Alignment.CenterVertically),
+                                                contentDescription = "",
+                                                colorFilter = ColorFilter.tint(Color.Green)
                                         )
 
                                         Spacer(modifier = Modifier.width(20.dp))
 
                                         Text(
-                                            text = item.player_name,
-                                            fontSize = 14.sp,
-                                            modifier = Modifier.align(CenterVertically)
+                                                text = item.player_name,
+                                                fontSize = 14.sp,
+                                                modifier = Modifier.align(CenterVertically)
                                         )
                                     }
                                 }
@@ -306,9 +306,9 @@ fun TabScreenOne(tabName: String, match: List<MatchEvent>, one: Int, two: Int) {
                     if (item.team_id == two) {
 
                         Column(
-                            modifier = Modifier
-                                .align(End)
-                                .fillMaxSize()
+                                modifier = Modifier
+                                        .align(End)
+                                        .fillMaxSize()
                         ) {
                             Column(modifier = Modifier.align(Alignment.End)) {
                                 if (item.type == "goal") {
@@ -316,15 +316,15 @@ fun TabScreenOne(tabName: String, match: List<MatchEvent>, one: Int, two: Int) {
 
                                         Column(modifier = Modifier.align(Alignment.CenterVertically)) {
                                             Text(
-                                                text = item.player_name + "(${item.result})",
-                                                fontWeight = FontWeight.Bold,
-                                                fontSize = 14.sp
+                                                    text = item.player_name + "(${item.result})",
+                                                    fontWeight = FontWeight.Bold,
+                                                    fontSize = 14.sp
                                             )
                                             if (item.related_player_name != null) {
                                                 Text(
-                                                    text = "Assist by " + item.related_player_name,
-                                                    color = Color.Gray,
-                                                    fontSize = 12.sp
+                                                        text = "Assist by " + item.related_player_name,
+                                                        color = Color.Gray,
+                                                        fontSize = 12.sp
                                                 )
                                             }
                                         }
@@ -332,23 +332,23 @@ fun TabScreenOne(tabName: String, match: List<MatchEvent>, one: Int, two: Int) {
                                         Spacer(modifier = Modifier.width(4.dp))
 
                                         Image(
-                                            painter = painterResource(id = R.drawable.reggae),
-                                            modifier = Modifier
-                                                .height(38.dp)
-                                                .width(38.dp)
-                                                .padding(10.dp)
-                                                .align(Alignment.CenterVertically),
-                                            contentDescription = "",
+                                                painter = painterResource(id = R.drawable.reggae),
+                                                modifier = Modifier
+                                                        .height(38.dp)
+                                                        .width(38.dp)
+                                                        .padding(10.dp)
+                                                        .align(Alignment.CenterVertically),
+                                                contentDescription = "",
 
-                                        )
+                                                )
 
                                         Spacer(modifier = Modifier.width(4.dp))
 
                                         Text(
-                                            text = item.minute.toString(),
-                                            fontWeight = FontWeight.Bold,
-                                            modifier = Modifier.align(Alignment.CenterVertically),
-                                            fontSize = 15.sp
+                                                text = item.minute.toString(),
+                                                fontWeight = FontWeight.Bold,
+                                                modifier = Modifier.align(Alignment.CenterVertically),
+                                                fontSize = 15.sp
                                         )
                                     }
                                 }
@@ -359,16 +359,16 @@ fun TabScreenOne(tabName: String, match: List<MatchEvent>, one: Int, two: Int) {
 
                                         Column {
                                             Text(
-                                                text = item.related_player_name,
-                                                fontSize = 14.sp,
-                                                color = Color.Green
+                                                    text = item.related_player_name,
+                                                    fontSize = 14.sp,
+                                                    color = Color.Green
                                             )
                                             Spacer(modifier = Modifier.height(1.dp))
 
                                             Text(
-                                                text = item.player_name,
-                                                fontSize = 14.sp,
-                                                color = Color.Red
+                                                    text = item.player_name,
+                                                    fontSize = 14.sp,
+                                                    color = Color.Red
                                             )
                                         }
 
@@ -376,23 +376,23 @@ fun TabScreenOne(tabName: String, match: List<MatchEvent>, one: Int, two: Int) {
 
                                         Column {
                                             Card(
-                                                shape = RoundedCornerShape(100.dp),
-                                                modifier = Modifier.padding(top = 4.dp)
+                                                    shape = RoundedCornerShape(100.dp),
+                                                    modifier = Modifier.padding(top = 4.dp)
                                             ) {
                                                 Column {
                                                     Row(
-                                                        modifier = Modifier
-                                                            .size(14.dp)
-                                                            .background(Color.Green)
+                                                            modifier = Modifier
+                                                                    .size(14.dp)
+                                                                    .background(Color.Green)
                                                     ) {
                                                         Image(
-                                                            imageVector = Icons.Default.ArrowBack,
-                                                            modifier = Modifier
-                                                                .fillMaxSize()
-                                                                .padding(2.dp)
-                                                                .align(Alignment.CenterVertically),
-                                                            contentDescription = "",
-                                                            colorFilter = ColorFilter.tint(Color.White)
+                                                                imageVector = Icons.Default.ArrowBack,
+                                                                modifier = Modifier
+                                                                        .fillMaxSize()
+                                                                        .padding(2.dp)
+                                                                        .align(Alignment.CenterVertically),
+                                                                contentDescription = "",
+                                                                colorFilter = ColorFilter.tint(Color.White)
                                                         )
                                                     }
                                                 }
@@ -401,23 +401,23 @@ fun TabScreenOne(tabName: String, match: List<MatchEvent>, one: Int, two: Int) {
                                             Spacer(modifier = Modifier.height(1.dp))
 
                                             Card(
-                                                shape = RoundedCornerShape(100.dp),
-                                                modifier = Modifier
+                                                    shape = RoundedCornerShape(100.dp),
+                                                    modifier = Modifier
                                             ) {
                                                 Column {
                                                     Row(
-                                                        modifier = Modifier
-                                                            .size(14.dp)
-                                                            .background(Color.Red)
+                                                            modifier = Modifier
+                                                                    .size(14.dp)
+                                                                    .background(Color.Red)
                                                     ) {
                                                         Image(
-                                                            imageVector = Icons.Default.ArrowForward,
-                                                            modifier = Modifier
-                                                                .fillMaxSize()
-                                                                .padding(2.dp)
-                                                                .align(Alignment.CenterVertically),
-                                                            contentDescription = "",
-                                                            colorFilter = ColorFilter.tint(Color.White)
+                                                                imageVector = Icons.Default.ArrowForward,
+                                                                modifier = Modifier
+                                                                        .fillMaxSize()
+                                                                        .padding(2.dp)
+                                                                        .align(Alignment.CenterVertically),
+                                                                contentDescription = "",
+                                                                colorFilter = ColorFilter.tint(Color.White)
                                                         )
                                                     }
                                                 }
@@ -427,126 +427,126 @@ fun TabScreenOne(tabName: String, match: List<MatchEvent>, one: Int, two: Int) {
                                         Spacer(modifier = Modifier.width(18.dp))
 
                                         Text(
-                                            text = item.minute.toString(),
-                                            fontWeight = FontWeight.Bold,
-                                            modifier = Modifier.align(Alignment.CenterVertically),
-                                            fontSize = 15.sp
+                                                text = item.minute.toString(),
+                                                fontWeight = FontWeight.Bold,
+                                                modifier = Modifier.align(Alignment.CenterVertically),
+                                                fontSize = 15.sp
                                         )
                                     }
                                 }
                                 if (item.type == "yellowcard") {
                                     Row(
-                                        modifier = Modifier.padding(
-                                            end = 16.dp,
-                                            top = 8.dp,
-                                            bottom = 8.dp
-                                        )
+                                            modifier = Modifier.padding(
+                                                    end = 16.dp,
+                                                    top = 8.dp,
+                                                    bottom = 8.dp
+                                            )
                                     ) {
                                         Text(
-                                            text = item.player_name,
-                                            fontSize = 14.sp,
-                                            modifier = Modifier.align(CenterVertically)
+                                                text = item.player_name,
+                                                fontSize = 14.sp,
+                                                modifier = Modifier.align(CenterVertically)
                                         )
 
                                         Spacer(modifier = Modifier.width(20.dp))
 
                                         Card(
-                                            modifier = Modifier
-                                                .align(Alignment.CenterVertically)
-                                                .height(16.dp)
-                                                .width(12.dp)
-                                                .background(
-                                                    Color.Yellow
-                                                )
+                                                modifier = Modifier
+                                                        .align(Alignment.CenterVertically)
+                                                        .height(16.dp)
+                                                        .width(12.dp)
+                                                        .background(
+                                                                Color.Yellow
+                                                        )
                                         ) {
                                             Box(
-                                                modifier = Modifier
-                                                    .fillMaxSize()
-                                                    .background(Color.Yellow)
+                                                    modifier = Modifier
+                                                            .fillMaxSize()
+                                                            .background(Color.Yellow)
                                             )
                                         }
 
                                         Spacer(modifier = Modifier.width(18.dp))
 
                                         Text(
-                                            text = item.minute.toString(),
-                                            fontWeight = FontWeight.Bold,
-                                            modifier = Modifier.align(Alignment.CenterVertically),
-                                            fontSize = 15.sp
+                                                text = item.minute.toString(),
+                                                fontWeight = FontWeight.Bold,
+                                                modifier = Modifier.align(Alignment.CenterVertically),
+                                                fontSize = 15.sp
                                         )
                                     }
                                 }
                                 if (item.type == "injury") {
                                     Row(
-                                        modifier = Modifier.padding(
-                                            end = 16.dp,
-                                            top = 8.dp,
-                                            bottom = 8.dp
-                                        )
+                                            modifier = Modifier.padding(
+                                                    end = 16.dp,
+                                                    top = 8.dp,
+                                                    bottom = 8.dp
+                                            )
                                     ) {
 
                                         Text(
-                                            text = item.player_name,
-                                            fontSize = 14.sp,
-                                            modifier = Modifier.align(CenterVertically)
+                                                text = item.player_name,
+                                                fontSize = 14.sp,
+                                                modifier = Modifier.align(CenterVertically)
                                         )
 
                                         Spacer(modifier = Modifier.width(20.dp))
 
                                         Image(
-                                            imageVector = Icons.Default.Warning,
-                                            modifier = Modifier
-                                                .size(22.dp)
-                                                .padding(2.dp)
-                                                .align(Alignment.CenterVertically),
-                                            contentDescription = "",
-                                            colorFilter = ColorFilter.tint(Color.Red)
+                                                imageVector = Icons.Default.Warning,
+                                                modifier = Modifier
+                                                        .size(22.dp)
+                                                        .padding(2.dp)
+                                                        .align(Alignment.CenterVertically),
+                                                contentDescription = "",
+                                                colorFilter = ColorFilter.tint(Color.Red)
                                         )
 
                                         Spacer(modifier = Modifier.width(18.dp))
 
                                         Text(
-                                            text = item.minute.toString(),
-                                            fontWeight = FontWeight.Bold,
-                                            modifier = Modifier.align(Alignment.CenterVertically),
-                                            fontSize = 15.sp
+                                                text = item.minute.toString(),
+                                                fontWeight = FontWeight.Bold,
+                                                modifier = Modifier.align(Alignment.CenterVertically),
+                                                fontSize = 15.sp
                                         )
                                     }
                                 }
                                 if (item.type == "back from injury") {
                                     Row(
-                                        modifier = Modifier.padding(
-                                            end = 16.dp,
-                                            top = 8.dp,
-                                            bottom = 8.dp
-                                        )
+                                            modifier = Modifier.padding(
+                                                    end = 16.dp,
+                                                    top = 8.dp,
+                                                    bottom = 8.dp
+                                            )
                                     ) {
 
                                         Text(
-                                            text = item.player_name,
-                                            fontSize = 14.sp,
-                                            modifier = Modifier.align(CenterVertically)
+                                                text = item.player_name,
+                                                fontSize = 14.sp,
+                                                modifier = Modifier.align(CenterVertically)
                                         )
 
                                         Spacer(modifier = Modifier.width(20.dp))
 
                                         Image(
-                                            imageVector = Icons.Default.Add,
-                                            modifier = Modifier
-                                                .size(22.dp)
-                                                .padding(2.dp)
-                                                .align(Alignment.CenterVertically),
-                                            contentDescription = "",
-                                            colorFilter = ColorFilter.tint(Color.Green)
+                                                imageVector = Icons.Default.Add,
+                                                modifier = Modifier
+                                                        .size(22.dp)
+                                                        .padding(2.dp)
+                                                        .align(Alignment.CenterVertically),
+                                                contentDescription = "",
+                                                colorFilter = ColorFilter.tint(Color.Green)
                                         )
 
                                         Spacer(modifier = Modifier.width(18.dp))
 
                                         Text(
-                                            text = item.minute.toString(),
-                                            fontWeight = FontWeight.Bold,
-                                            modifier = Modifier.align(Alignment.CenterVertically),
-                                            fontSize = 15.sp
+                                                text = item.minute.toString(),
+                                                fontWeight = FontWeight.Bold,
+                                                modifier = Modifier.align(Alignment.CenterVertically),
+                                                fontSize = 15.sp
                                         )
                                     }
                                 }
@@ -562,22 +562,22 @@ fun TabScreenOne(tabName: String, match: List<MatchEvent>, one: Int, two: Int) {
 @Composable
 fun TabScreenTwo(tabName: String, lineup: List<Lineup>, one: Int, two: Int) {
     Card(
-        modifier = Modifier
-            .padding(6.dp)
-            .fillMaxSize(),
-        shape = RoundedCornerShape(6.dp),
-        elevation = 3.dp,
+            modifier = Modifier
+                    .padding(6.dp)
+                    .fillMaxSize(),
+            shape = RoundedCornerShape(6.dp),
+            elevation = 3.dp,
     ) {
         Column(
-            modifier = Modifier.fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
         ) {
 
             LazyRow(
-                modifier = Modifier
-                    .fillMaxSize(),
-                horizontalArrangement = Arrangement.SpaceBetween
+                    modifier = Modifier
+                            .fillMaxSize(),
+                    horizontalArrangement = SpaceBetween
             ) {
                 items(items = lineup) { item ->
 
@@ -590,38 +590,38 @@ fun TabScreenTwo(tabName: String, lineup: List<Lineup>, one: Int, two: Int) {
 
                                     Row(modifier = Modifier.padding(top = 16.dp)) {
                                         Card(
-                                            shape = RoundedCornerShape(100.dp),
-                                            modifier = Modifier.align(CenterVertically)
+                                                shape = RoundedCornerShape(100.dp),
+                                                modifier = Modifier.align(CenterVertically)
                                         ) {
                                             Column {
                                                 Row(
-                                                    modifier = Modifier
-                                                        .size(20.dp)
+                                                        modifier = Modifier
+                                                                .size(20.dp)
                                                 ) {
                                                     Image(
-                                                        painter = painterResource(id = R.drawable.reggae),
-                                                        modifier = Modifier
-                                                            .fillMaxSize()
-                                                            .align(Alignment.CenterVertically),
-                                                        contentDescription = "",
+                                                            painter = painterResource(id = R.drawable.reggae),
+                                                            modifier = Modifier
+                                                                    .fillMaxSize()
+                                                                    .align(Alignment.CenterVertically),
+                                                            contentDescription = "",
                                                     )
                                                 }
                                             }
                                         }
                                         Spacer(modifier = Modifier.width(12.dp))
                                         Text(
-                                            text = items.lastname,
-                                            fontSize = 14.sp,
-                                            modifier = Modifier.align(CenterVertically)
+                                                text = items.lastname,
+                                                fontSize = 14.sp,
+                                                modifier = Modifier.align(CenterVertically)
                                         )
 
                                         Spacer(modifier = Modifier.width(20.dp))
 
                                         Text(
-                                            text = items.detailed.number.toString(),
-                                            fontWeight = FontWeight.Bold,
-                                            modifier = Modifier.align(Alignment.CenterVertically),
-                                            fontSize = 15.sp
+                                                text = items.detailed.number.toString(),
+                                                fontWeight = FontWeight.Bold,
+                                                modifier = Modifier.align(Alignment.CenterVertically),
+                                                fontSize = 15.sp
                                         )
                                     }
                                 }
@@ -631,52 +631,52 @@ fun TabScreenTwo(tabName: String, lineup: List<Lineup>, one: Int, two: Int) {
 
                     if (item.team_id == two) {
                         LazyColumn(
-                            modifier = Modifier
-                                .align(End)
-                                .padding(end = 12.dp)
-                                .fillMaxSize()
+                                modifier = Modifier
+                                        .align(End)
+                                        .padding(end = 12.dp)
+                                        .fillMaxSize()
                         ) {
                             items(items = item.players) { items ->
                                 Column(
-                                    modifier = Modifier
-                                        .align(End)
-                                        .fillMaxSize()
+                                        modifier = Modifier
+                                                .align(End)
+                                                .fillMaxSize()
                                 ) {
 
                                     Row(modifier = Modifier.padding(top = 16.dp)) {
                                         Card(
-                                            shape = RoundedCornerShape(100.dp),
-                                            modifier = Modifier.align(CenterVertically)
+                                                shape = RoundedCornerShape(100.dp),
+                                                modifier = Modifier.align(CenterVertically)
                                         ) {
                                             Column {
                                                 Row(
-                                                    modifier = Modifier
-                                                        .size(20.dp)
+                                                        modifier = Modifier
+                                                                .size(20.dp)
                                                 ) {
                                                     Image(
-                                                        painter = painterResource(id = R.drawable.reggae),
-                                                        modifier = Modifier
-                                                            .fillMaxSize()
-                                                            .align(Alignment.CenterVertically),
-                                                        contentDescription = "",
+                                                            painter = painterResource(id = R.drawable.reggae),
+                                                            modifier = Modifier
+                                                                    .fillMaxSize()
+                                                                    .align(Alignment.CenterVertically),
+                                                            contentDescription = "",
                                                     )
                                                 }
                                             }
                                         }
                                         Spacer(modifier = Modifier.width(12.dp))
                                         Text(
-                                            text = items.lastname,
-                                            fontSize = 14.sp,
-                                            modifier = Modifier.align(CenterVertically)
+                                                text = items.lastname,
+                                                fontSize = 14.sp,
+                                                modifier = Modifier.align(CenterVertically)
                                         )
 
                                         Spacer(modifier = Modifier.width(20.dp))
 
                                         Text(
-                                            text = items.detailed.number.toString(),
-                                            fontWeight = FontWeight.Bold,
-                                            modifier = Modifier.align(Alignment.CenterVertically),
-                                            fontSize = 15.sp
+                                                text = items.detailed.number.toString(),
+                                                fontWeight = FontWeight.Bold,
+                                                modifier = Modifier.align(Alignment.CenterVertically),
+                                                fontSize = 15.sp
                                         )
                                     }
                                 }
@@ -692,16 +692,20 @@ fun TabScreenTwo(tabName: String, lineup: List<Lineup>, one: Int, two: Int) {
 @Composable
 fun TabScreenThree(tabName: String, stata: MatchDetailsModel) {
     Card(
-        modifier = Modifier
-            .padding(6.dp)
-            .fillMaxSize(),
-        shape = RoundedCornerShape(6.dp),
-        elevation = 3.dp,
+            modifier = Modifier
+                    .padding(6.dp)
+                    .fillMaxSize(),
+            shape = RoundedCornerShape(6.dp),
+            elevation = 3.dp,
 
-    ) {
+            ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Top, modifier = Modifier.fillMaxSize()
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Top,
+                modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+
         ) {
             PokemonBaseStats(pokemonInfo = stata)
             Spacer(modifier = Modifier.height(8.dp))
@@ -735,28 +739,28 @@ fun PokemonBaseStats(
         pokemonInfo.match_statistics.maxOf { it.shots_on_target }
     }
     Column(
-        modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
     ) {
         Text(
-            text = "Shots on Target",
-            fontSize = 16.sp,
-            color = MaterialTheme.colors.onSurface,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
+                text = "Shots on Target",
+                fontSize = 16.sp,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
         )
         Spacer(modifier = Modifier.height(4.dp))
 
         Row(
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             for (i in pokemonInfo.match_statistics.indices) {
                 val stat = pokemonInfo.match_statistics[i]
                 PokemonStat(
-                    statName = "Shots on target",
-                    statValue = stat.shots_on_target,
-                    statMaxValue = maxBaseStat,
-                    statColor = SpAtkColor,
-                    animDelay = i * animDelayPerItem
+                        statName = "Shots on target",
+                        statValue = stat.shots_on_target,
+                        statMaxValue = maxBaseStat,
+                        statColor = SpAtkColor,
+                        animDelay = i * animDelayPerItem
                 )
                 Spacer(modifier = Modifier.height(8.dp))
             }
@@ -778,44 +782,51 @@ fun PokemonStat(
         mutableStateOf(false)
     }
     val curPercent = animateFloatAsState(
-        targetValue = if (animationPlayed) {
-            statValue / statMaxValue.toFloat()
-        } else 0f,
-        animationSpec = tween(
-            animDuration,
-            animDelay
-        )
+            targetValue = if (animationPlayed) {
+                statValue / statMaxValue.toFloat()
+            } else 0f,
+            animationSpec = tween(
+                    animDuration,
+                    animDelay
+            )
     )
     LaunchedEffect(key1 = true) {
         animationPlayed = true
     }
     Box(
-        modifier = Modifier
-            .width(150.dp)
-            .height(height)
-            .clip(CircleShape)
-            .background(
-                if (isSystemInDarkTheme()) {
-                    Color(0xFF505050)
-                } else {
-                    Color.LightGray
-                }
-            )
+            modifier = Modifier
+                    .width(150.dp)
+                    .clip(CircleShape)
+                    .background(
+                            if (isSystemInDarkTheme()) {
+                                Color(0xFF505050)
+                            } else {
+                                Color.LightGray
+                            }
+                    ),
+            contentAlignment = Alignment.TopStart
     ) {
         Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxHeight()
-                .fillMaxWidth(curPercent.value)
-                .clip(CircleShape)
-                .background(statColor)
-                .padding(horizontal = 8.dp)
+                horizontalArrangement = SpaceBetween,
+                verticalAlignment = CenterVertically,
+                modifier = Modifier
+
+                        .fillMaxWidth(curPercent.value)
+                        .clip(CircleShape)
+                        .background(statColor)
+                        .padding(horizontal = 8.dp, vertical =2.dp)
         ) {
 
             Text(
-                text = (curPercent.value * statMaxValue).toInt().toString(),
-                fontWeight = FontWeight.Bold, color = Color.White
+                    text = (curPercent.value * statMaxValue).toInt()
+                            .toString(),
+                    fontWeight = FontWeight.Bold, color = Color.White,
+                    modifier = Modifier
+                            .height(height)
+                            .align(CenterVertically),
+                    style = MaterialTheme.typography.caption,
+
+
             )
         }
     }
@@ -830,28 +841,28 @@ fun AttacksAnimation(
         pokemonInfo.match_statistics.maxOf { it.attacks }
     }
     Column(
-        modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
     ) {
         Text(
-            text = "Attacks",
-            fontSize = 16.sp,
-            color = MaterialTheme.colors.onSurface,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
+                text = "Attacks",
+                fontSize = 16.sp,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
         )
         Spacer(modifier = Modifier.height(4.dp))
 
         Row(
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             for (i in pokemonInfo.match_statistics.indices) {
                 val stat = pokemonInfo.match_statistics[i]
                 PokemonStat(
-                    statName = "",
-                    statValue = stat.attacks,
-                    statMaxValue = maxBaseStat,
-                    statColor = SpAtkColor,
-                    animDelay = i * animDelayPerItem
+                        statName = "",
+                        statValue = stat.attacks,
+                        statMaxValue = maxBaseStat,
+                        statColor = SpAtkColor,
+                        animDelay = i * animDelayPerItem
                 )
                 Spacer(modifier = Modifier.height(8.dp))
             }
@@ -868,28 +879,28 @@ fun BallSafeAnimation(
         pokemonInfo.match_statistics.maxOf { it.ball_safe }
     }
     Column(
-        modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
     ) {
         Text(
-            text = "Ball safe",
-            fontSize = 16.sp,
-            color = MaterialTheme.colors.onSurface,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
+                text = "Ball safe",
+                fontSize = 16.sp,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
         )
         Spacer(modifier = Modifier.height(4.dp))
 
         Row(
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             for (i in pokemonInfo.match_statistics.indices) {
                 val stat = pokemonInfo.match_statistics[i]
                 PokemonStat(
-                    statName = "",
-                    statValue = stat.ball_safe,
-                    statMaxValue = maxBaseStat,
-                    statColor = SpAtkColor,
-                    animDelay = i * animDelayPerItem
+                        statName = "",
+                        statValue = stat.ball_safe,
+                        statMaxValue = maxBaseStat,
+                        statColor = SpAtkColor,
+                        animDelay = i * animDelayPerItem
                 )
                 Spacer(modifier = Modifier.height(8.dp))
             }
@@ -906,28 +917,28 @@ fun CornersAnimation(
         pokemonInfo.match_statistics.maxOf { it.corners }
     }
     Column(
-        modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
     ) {
         Text(
-            text = "Corners",
-            fontSize = 16.sp,
-            color = MaterialTheme.colors.onSurface,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
+                text = "Corners",
+                fontSize = 16.sp,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
         )
         Spacer(modifier = Modifier.height(4.dp))
 
         Row(
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             for (i in pokemonInfo.match_statistics.indices) {
                 val stat = pokemonInfo.match_statistics[i]
                 PokemonStat(
-                    statName = "",
-                    statValue = stat.corners,
-                    statMaxValue = maxBaseStat,
-                    statColor = SpAtkColor,
-                    animDelay = i * animDelayPerItem
+                        statName = "",
+                        statValue = stat.corners,
+                        statMaxValue = maxBaseStat,
+                        statColor = SpAtkColor,
+                        animDelay = i * animDelayPerItem
                 )
                 Spacer(modifier = Modifier.height(8.dp))
             }
@@ -944,28 +955,28 @@ fun DangerousAttacksAnimation(
         pokemonInfo.match_statistics.maxOf { it.dangerous_attacks }
     }
     Column(
-        modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
     ) {
         Text(
-            text = "Dangerous attacks",
-            fontSize = 16.sp,
-            color = MaterialTheme.colors.onSurface,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
+                text = "Dangerous attacks",
+                fontSize = 16.sp,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
         )
         Spacer(modifier = Modifier.height(4.dp))
 
         Row(
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             for (i in pokemonInfo.match_statistics.indices) {
                 val stat = pokemonInfo.match_statistics[i]
                 PokemonStat(
-                    statName = "",
-                    statValue = stat.dangerous_attacks,
-                    statMaxValue = maxBaseStat,
-                    statColor = SpAtkColor,
-                    animDelay = i * animDelayPerItem
+                        statName = "",
+                        statValue = stat.dangerous_attacks,
+                        statMaxValue = maxBaseStat,
+                        statColor = SpAtkColor,
+                        animDelay = i * animDelayPerItem
                 )
                 Spacer(modifier = Modifier.height(8.dp))
             }
@@ -982,28 +993,28 @@ fun FoulsAnimation(
         pokemonInfo.match_statistics.maxOf { it.fouls }
     }
     Column(
-        modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
     ) {
         Text(
-            text = "Fouls",
-            fontSize = 16.sp,
-            color = MaterialTheme.colors.onSurface,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
+                text = "Fouls",
+                fontSize = 16.sp,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
         )
         Spacer(modifier = Modifier.height(4.dp))
 
         Row(
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             for (i in pokemonInfo.match_statistics.indices) {
                 val stat = pokemonInfo.match_statistics[i]
                 PokemonStat(
-                    statName = "",
-                    statValue = stat.fouls,
-                    statMaxValue = maxBaseStat,
-                    statColor = SpAtkColor,
-                    animDelay = i * animDelayPerItem
+                        statName = "",
+                        statValue = stat.fouls,
+                        statMaxValue = maxBaseStat,
+                        statColor = SpAtkColor,
+                        animDelay = i * animDelayPerItem
                 )
                 Spacer(modifier = Modifier.height(8.dp))
             }
@@ -1020,28 +1031,28 @@ fun FreeKickAnimation(
         pokemonInfo.match_statistics.maxOf { it.free_kick }
     }
     Column(
-        modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
     ) {
         Text(
-            text = "Free kicks",
-            fontSize = 16.sp,
-            color = MaterialTheme.colors.onSurface,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
+                text = "Free kicks",
+                fontSize = 16.sp,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
         )
         Spacer(modifier = Modifier.height(4.dp))
 
         Row(
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             for (i in pokemonInfo.match_statistics.indices) {
                 val stat = pokemonInfo.match_statistics[i]
                 PokemonStat(
-                    statName = "",
-                    statValue = stat.free_kick,
-                    statMaxValue = maxBaseStat,
-                    statColor = SpAtkColor,
-                    animDelay = i * animDelayPerItem
+                        statName = "",
+                        statValue = stat.free_kick,
+                        statMaxValue = maxBaseStat,
+                        statColor = SpAtkColor,
+                        animDelay = i * animDelayPerItem
                 )
                 Spacer(modifier = Modifier.height(8.dp))
             }
@@ -1058,28 +1069,28 @@ fun GoalAttemptsAnimation(
         pokemonInfo.match_statistics.maxOf { it.goal_attempts }
     }
     Column(
-        modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
     ) {
         Text(
-            text = "Goal attempts",
-            fontSize = 16.sp,
-            color = MaterialTheme.colors.onSurface,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
+                text = "Goal attempts",
+                fontSize = 16.sp,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
         )
         Spacer(modifier = Modifier.height(4.dp))
 
         Row(
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             for (i in pokemonInfo.match_statistics.indices) {
                 val stat = pokemonInfo.match_statistics[i]
                 PokemonStat(
-                    statName = "",
-                    statValue = stat.goal_attempts,
-                    statMaxValue = maxBaseStat,
-                    statColor = SpAtkColor,
-                    animDelay = i * animDelayPerItem
+                        statName = "",
+                        statValue = stat.goal_attempts,
+                        statMaxValue = maxBaseStat,
+                        statColor = SpAtkColor,
+                        animDelay = i * animDelayPerItem
                 )
                 Spacer(modifier = Modifier.height(8.dp))
             }
@@ -1096,28 +1107,28 @@ fun GoalKickAnimation(
         pokemonInfo.match_statistics.maxOf { it.goal_kick }
     }
     Column(
-        modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
     ) {
         Text(
-            text = "Goal kick",
-            fontSize = 16.sp,
-            color = MaterialTheme.colors.onSurface,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
+                text = "Goal kick",
+                fontSize = 16.sp,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
         )
         Spacer(modifier = Modifier.height(4.dp))
 
         Row(
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             for (i in pokemonInfo.match_statistics.indices) {
                 val stat = pokemonInfo.match_statistics[i]
                 PokemonStat(
-                    statName = "",
-                    statValue = stat.goal_kick,
-                    statMaxValue = maxBaseStat,
-                    statColor = SpAtkColor,
-                    animDelay = i * animDelayPerItem
+                        statName = "",
+                        statValue = stat.goal_kick,
+                        statMaxValue = maxBaseStat,
+                        statColor = SpAtkColor,
+                        animDelay = i * animDelayPerItem
                 )
                 Spacer(modifier = Modifier.height(8.dp))
             }
@@ -1134,28 +1145,28 @@ fun GoalsAnimation(
         pokemonInfo.match_statistics.maxOf { it.goals }
     }
     Column(
-        modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
     ) {
         Text(
-            text = "Goals",
-            fontSize = 16.sp,
-            color = MaterialTheme.colors.onSurface,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
+                text = "Goals",
+                fontSize = 16.sp,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
         )
         Spacer(modifier = Modifier.height(4.dp))
 
         Row(
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             for (i in pokemonInfo.match_statistics.indices) {
                 val stat = pokemonInfo.match_statistics[i]
                 PokemonStat(
-                    statName = "",
-                    statValue = stat.goals,
-                    statMaxValue = maxBaseStat,
-                    statColor = SpAtkColor,
-                    animDelay = i * animDelayPerItem
+                        statName = "",
+                        statValue = stat.goals,
+                        statMaxValue = maxBaseStat,
+                        statColor = SpAtkColor,
+                        animDelay = i * animDelayPerItem
                 )
                 Spacer(modifier = Modifier.height(8.dp))
             }


### PR DESCRIPTION
I changed the appearance of PokemonStat by centering the statics text and increasing the containing row padding. I also made the TabThree column scrollable. This way the statics are more readable.

![comp](https://user-images.githubusercontent.com/31527935/209423383-9f3dd4c1-0d9a-4b34-b713-e5dd3437bf61.png)

